### PR TITLE
fixes metrics server bug

### DIFF
--- a/04 Kubernetes meistern/12 Dienste automatisch skalieren/hpa.demo
+++ b/04 Kubernetes meistern/12 Dienste automatisch skalieren/hpa.demo
@@ -4,7 +4,7 @@
 kind create cluster --config kind.yaml
 
 ## Metrics-Server ausrollen
-curl -sLf https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.7/components.yaml | kubectl apply -f -
+curl -sLf https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.4/components.yaml | kubectl apply -f -
 
 ## Metrics-Server patchen
 kubectl --namespace=kube-system patch deployment metrics-server --type strategic --patch "$(cat metrics-server-patch.yaml)"


### PR DESCRIPTION
### Referring 4/12 hpa.demo:

Use new version of the metrics server to work with current version of kubernetes.

With the metrics server version in the script, this error occurs:
`curl -sLf https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.7/components.yaml | kubectl apply -f -
clusterrole.rbac.authorization.k8s.io/system:aggregated-metrics-reader unchanged
clusterrolebinding.rbac.authorization.k8s.io/metrics-server:system:auth-delegator unchanged
rolebinding.rbac.authorization.k8s.io/metrics-server-auth-reader unchanged
serviceaccount/metrics-server unchanged
deployment.apps/metrics-server unchanged
service/metrics-server unchanged
clusterrole.rbac.authorization.k8s.io/system:metrics-server unchanged
clusterrolebinding.rbac.authorization.k8s.io/system:metrics-server unchanged
error: resource mapping not found for name: "v1beta1.metrics.k8s.io" namespace: "" from "STDIN": no matches for kind "APIService" in version "apiregistration.k8s.io/v1beta1"
ensure CRDs are installed first`